### PR TITLE
添加Docker以及Docker Compose的部署方式

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# 使用 Node.js 官方镜像作为基础镜像
+FROM node:22.14.0
+
+# 设置工作目录
+WORKDIR /app
+
+# 将项目文件复制到容器内
+COPY . .
+
+# 安装项目依赖
+RUN npm install
+
+# 暴露端口
+EXPOSE 3000
+
+# 设置启动脚本为可执行文件
+RUN chmod +x start.sh
+
+# 定义默认的启动命令
+CMD ["./docker-start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # 使用 Node.js 官方镜像作为基础镜像
-FROM node:22.14.0
+FROM node:20.17.0
 
 # 设置工作目录
 WORKDIR /app
 
 # 将项目文件复制到容器内
-COPY . .
+COPY . /app
 
 # 安装项目依赖
 RUN npm install
@@ -14,7 +14,7 @@ RUN npm install
 EXPOSE 3000
 
 # 设置启动脚本为可执行文件
-RUN chmod +x start.sh
+RUN chmod +x /app/docker-start.sh
 
 # 定义默认的启动命令
-CMD ["./docker-start.sh"]
+CMD ["/app/docker-start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,5 @@ services:
     restart: always
     ports:
       - "3333:3000"
-    volumes:
-      -/yourpath/config.js:/app/config.js
     environment:
       - MODE=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  prose-polish:
+    image: prose-polish:latest
+    container_name: prose-polish
+    restart: always
+    ports:
+      - "3333:3000"
+    volumes:
+      -/yourpath/config.js:/app/config.js
+    environment:
+      - MODE=1

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# 检查是否存在 config.js
+if [ ! -f "config.js" ]; then
+    echo "未检测到配置文件请检查是否正确挂载config.js"
+    exit 1
+fi
+
+# 检查依赖是否安装
+if [ ! -d "node_modules" ]; then
+    echo "\n${GREEN}正在安装项目依赖..."
+    npm install
+fi
+
+# 读取启动模式，1 为完整模式，2 为本地模式
+mode=${MODE:-1}  # 默认值为 1
+
+case $mode in
+    1)
+        echo "正在启动完整模式..."
+        npm start
+        ;;
+    2)
+        echo "正在启动本地模式..."
+        npm run dev
+        ;;
+    *)
+        echo "无效的启动模式，请设置 MODE 环境变量为 1 或 2。"
+        exit 1
+        ;;
+esac

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# 检查是否存在 config.js
-if [ ! -f "config.js" ]; then
-    echo "未检测到配置文件请检查是否正确挂载config.js"
-    exit 1
-fi
-
 # 检查依赖是否安装
 if [ ! -d "node_modules" ]; then
     echo "\n${GREEN}正在安装项目依赖..."


### PR DESCRIPTION
**没有修改README.md，麻烦开发者自行修改一下，下面我简述一下使用方法**

### 通过Docker部署

#### 前提条件

* 安装Docker: [Get Started | Docker](https://www.docker.com/get-started/)
* （可选）安装Docker Compose: [Install | Docker Docs](https://docs.docker.com/compose/install/)

git clone该项目并cd到项目目录，根据config.example.js在项目目录下创建config.js并配置

#### 构建与启动容器

  git clone并cd到项目路径（包含Dockerfile）
  ```
  docker build -t prose-polish:latest .
  ```

* 通过Docker启动
  ```
  docker run -d -p 3333:3000 -e MODE=1 --name prose-polish prose-polish:latest
  ```
* 通过Docker Compose启动
  ```
  docker compose up -d
  ```

#### 参数解释
* 3333 为可自定义映射到宿主机的端口，运行成功后地址为http://ip:3333
* MODE 必须正确设置为1（完整模式）或2（本地模式），如不传入则默认为1