### PR TITLE
fix: 修复UI样式错误

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -2,6 +2,7 @@
 .app-container {
     display: flex;
     min-height: 100vh;
+    overflow: hidden;
 }
 
 /* 侧边栏 */


### PR DESCRIPTION
在styles/layout.css文件中，针对.app-container样式进行了调整。
在.app-container里添加了overflow: hidden;属性，解决了页面底部出现空白区域的问题。
修改前：
![修改前](https://github.com/user-attachments/assets/62ffae19-bab1-49c0-bfe6-015eddf0e19c)
修改后：
![修改后](https://github.com/user-attachments/assets/1695c3e8-998a-4ab5-afd7-75fd4fd27ea2)
