### PR TITLE
feat: 启用Ollama流式传输并支持自定义接口URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ styles/
    - `server.js` 处理 API 代理
    - API 密钥配置在 `script.js`
 
+4. **Ollama 端口配置**
+   - 如果Ollama端口发生变化，请于 `script.js` 中的`OLLAMA_BASE_URL`项修改。
+
 ## 功能特点
 - 可视化的提示词编辑系统
   - 支持创建和编辑提示词卡片

--- a/config.example.js
+++ b/config.example.js
@@ -12,9 +12,6 @@ export const CONFIG = {
     // 获取方式：访问 https://platform.deepseek.com
     DEEPSEEK_API_KEY: 'your-deepseek-api-key-here',
 
-    // Ollama配置
-    OLLAMA_BASE_URL: 'http://localhost:11434', //可在此处修改端口
-
     // 自定义模型配置
     // 如果不需要自定义模型，可以保持为 null
     CUSTOM_MODEL: {

--- a/config.example.js
+++ b/config.example.js
@@ -12,6 +12,9 @@ export const CONFIG = {
     // 获取方式：访问 https://platform.deepseek.com
     DEEPSEEK_API_KEY: 'your-deepseek-api-key-here',
 
+    // Ollama配置
+    OLLAMA_BASE_URL: 'http://localhost:11434', //可在此处修改端口
+
     // 自定义模型配置
     // 如果不需要自定义模型，可以保持为 null
     CUSTOM_MODEL: {

--- a/script.js
+++ b/script.js
@@ -4,6 +4,10 @@ import { ConnectionManager } from './js/connectionManager.js';
 import { CONFIG } from './config.js';
 import { initializeCardManagement } from './js/promptCard.js';
 
+
+    // Ollama配置
+const OLLAMA_BASE_URL = 'http://localhost:11434'; //可在此处修改端口
+
 // 模型配置
 const MODEL_CONFIG = {
     DEEPSEEK: {
@@ -381,13 +385,13 @@ async function showOllamaDialog() {
     // 获取可用模型列表
     try {
         // 首先检查 Ollama 服务是否在运行
-        const healthCheck = await fetch(CONFIG.OLLAMA_BASE_URL);
+        const healthCheck = await fetch(OLLAMA_BASE_URL);
         if (!healthCheck.ok) {
             throw new Error('无法连接到 Ollama 服务');
         }
         
         // 获取已安装的模型列表
-        const response = await fetch(`${CONFIG.OLLAMA_BASE_URL}/api/tags`);
+        const response = await fetch(`${OLLAMA_BASE_URL}/api/tags`);
         if (!response.ok) {
             throw new Error('无法获取模型列表');
         }
@@ -530,7 +534,7 @@ async function callAIAPI(message, model) {
         }
 
         try {
-            const response = await fetch(`${CONFIG.OLLAMA_BASE_URL}/api/generate`, {
+            const response = await fetch(`${OLLAMA_BASE_URL}/api/generate`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/script.js
+++ b/script.js
@@ -381,13 +381,13 @@ async function showOllamaDialog() {
     // 获取可用模型列表
     try {
         // 首先检查 Ollama 服务是否在运行
-        const healthCheck = await fetch('http://localhost:11434');
+        const healthCheck = await fetch(CONFIG.OLLAMA_BASE_URL);
         if (!healthCheck.ok) {
             throw new Error('无法连接到 Ollama 服务');
         }
         
         // 获取已安装的模型列表
-        const response = await fetch('http://localhost:11434/api/tags');
+        const response = await fetch(`${CONFIG.OLLAMA_BASE_URL}/api/tags`);
         if (!response.ok) {
             throw new Error('无法获取模型列表');
         }
@@ -530,7 +530,7 @@ async function callAIAPI(message, model) {
         }
 
         try {
-            const response = await fetch('http://localhost:11434/api/generate', {
+            const response = await fetch(`${CONFIG.OLLAMA_BASE_URL}/api/generate`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/script.js
+++ b/script.js
@@ -539,7 +539,7 @@ async function callAIAPI(message, model) {
                     model: window.ollamaModel,
                     prompt: message,
                     system: API_CONFIG.SYSTEM_MESSAGE.content,
-                    stream: false,
+                    stream: true, // 启用流式传输
                     options: {
                         temperature: 0.7,
                         top_p: 0.9
@@ -553,9 +553,28 @@ async function callAIAPI(message, model) {
                 throw new Error(`Ollama API调用失败: ${errorData.error || '未知错误'}`);
             }
 
-            const data = await response.json();
-            console.log('Ollama响应数据:', data);
-            return data.response;
+            // 处理流式响应
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder('utf-8');
+            let result = '';
+            promptOutput.textContent = '';
+            const processStream = async () => {
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    try{
+                        const chunk = JSON.parse(decoder.decode(value, { stream: true }));
+                        if(chunk.response) {
+                            result += chunk.response;
+                            promptOutput.textContent += chunk.response;
+                            promptOutput.scrollTop = promptOutput.scrollHeight;
+                        }
+                    } catch { }
+                }
+                return result;
+            };
+
+            return processStream();
         } catch (error) {
             if (error.message.includes('Failed to fetch')) {
                 throw new Error('无法连接到 Ollama 服务。请确保：\n1. Ollama 已安装\n2. 已运行 `ollama serve`\n3. 选择的模型已经下载并运行');


### PR DESCRIPTION
在`config.js`里添加了`OLLAMA_BASE_URL`变量。
```
OLLAMA_BASE_URL: 'http://localhost:11434',
```
在`script.js`里使用`${CONFIG.OLLAMA_BASE_URL}`来构建正确的接口URL。
```
const healthCheck = await fetch(CONFIG.OLLAMA_BASE_URL);
……
const response = await fetch(`${CONFIG.OLLAMA_BASE_URL}/api/tags`);
……
const response = await fetch(`${CONFIG.OLLAMA_BASE_URL}/api/generate`, {
```
现在用户可以通过修改`config.js`，自定义Ollama接口的URL。