### PR TITLE
feat: 全部启用流式传输

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -7,6 +7,7 @@ export const CONFIG = {
     // 通义千问 API 密钥
     // 获取方式：访问 https://dashscope.aliyun.com/
     TONGYI_API_KEY: 'your-tongyi-api-key-here',
+    TONGYI_MODEL: 'qwen-turbo', // 可选：qwen-max（贵但好）、qwen-plus（高性价比）、qwen-turbo（便宜但笨），具体请参考：https://help.aliyun.com/zh/model-studio/getting-started/models
 
     // DeepSeek API 密钥
     // 获取方式：访问 https://platform.deepseek.com

--- a/config.example.js
+++ b/config.example.js
@@ -7,7 +7,7 @@ export const CONFIG = {
     // 通义千问 API 密钥
     // 获取方式：访问 https://dashscope.aliyun.com/
     TONGYI_API_KEY: 'your-tongyi-api-key-here',
-    TONGYI_MODEL: 'qwen-turbo', // 可选：qwen-max（贵但好）、qwen-plus（高性价比）、qwen-turbo（便宜但笨），具体请参考：https://help.aliyun.com/zh/model-studio/getting-started/models
+    TONGYI_MODEL: 'qwen-plus', // 可选：qwen-max（贵但好）、qwen-plus（高性价比）、qwen-turbo（便宜但笨），具体请参考：https://help.aliyun.com/zh/model-studio/getting-started/models
 
     // DeepSeek API 密钥
     // 获取方式：访问 https://platform.deepseek.com

--- a/config.example.js
+++ b/config.example.js
@@ -7,7 +7,6 @@ export const CONFIG = {
     // 通义千问 API 密钥
     // 获取方式：访问 https://dashscope.aliyun.com/
     TONGYI_API_KEY: 'your-tongyi-api-key-here',
-    TONGYI_MODEL: 'qwen-plus', // 可选：qwen-max（贵但好）、qwen-plus（高性价比）、qwen-turbo（便宜但笨），具体请参考：https://help.aliyun.com/zh/model-studio/getting-started/models
 
     // DeepSeek API 密钥
     // 获取方式：访问 https://platform.deepseek.com

--- a/script.js
+++ b/script.js
@@ -668,7 +668,7 @@ async function callAIAPI(message, model) {
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({
-                    model: CONFIG.TONGYI_MODEL,
+                    model: 'qwen-plus',
                     messages: [
                         API_CONFIG.SYSTEM_MESSAGE,
                         {

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ import { CONFIG } from './config.js';
 import { initializeCardManagement } from './js/promptCard.js';
 
 
-    // Ollama配置
+// Ollama配置
 const OLLAMA_BASE_URL = 'http://localhost:11434'; //可在此处修改端口
 
 // 模型配置
@@ -339,7 +339,7 @@ CUSTOM_MODEL: {
     BASE_URL: '${baseUrl}',
     API_KEY: '${apiKey}',
     MODEL: '${model}'
-}`;
+},`;
         
         console.log('新的自定义模型配置：');
         console.log(configText);
@@ -551,10 +551,6 @@ async function callAIAPI(message, model) {
                     prompt: message,
                     system: API_CONFIG.SYSTEM_MESSAGE.content,
                     stream: true, // 启用流式传输
-                    options: {
-                        temperature: 0.7,
-                        top_p: 0.9
-                    }
                 })
             });
 
@@ -584,7 +580,6 @@ async function callAIAPI(message, model) {
                 }
                 return result;
             };
-
             return processStream();
         } catch (error) {
             if (error.message.includes('Failed to fetch')) {
@@ -621,7 +616,8 @@ async function callAIAPI(message, model) {
                             role: 'user',
                             content: message
                         }
-                    ]
+                    ],
+                    stream: true,
                 })
             });
 
@@ -631,9 +627,35 @@ async function callAIAPI(message, model) {
                 throw new Error(`API调用失败: ${errorData.error?.message || '未知错误'}`);
             }
 
-            const data = await response.json();
-            console.log('自定义模型响应数据:', data);
-            return data.choices[0].message.content;
+            // 处理流式响应
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder('utf-8');
+            let result = '';
+            promptOutput.textContent = '';
+            const processStream = async () => {
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    try {
+                        const chunk = decoder.decode(value, { stream: true });
+                        const lines = chunk.split('\n').filter(line => line.trim() !== '');
+                        for (const line of lines) {
+                            if (line.startsWith("data: ")) {
+                                const data = line.slice(6).trim();
+                                if (data === "[DONE]") return result;
+                                try {
+                                    const parsedData = JSON.parse(data);
+                                    const content = parsedData.choices[0]?.delta?.content || '';
+                                    result += content;
+                                    promptOutput.textContent += content;
+                                    promptOutput.scrollTop = promptOutput.scrollHeight;
+                                } catch { }
+                            }
+                        }
+                    } catch { }
+                }
+            };
+            return processStream();
         } catch (error) {
             throw error;
         }


### PR DESCRIPTION
1. 为自定义模型接口启用流式传输。
2. 为阿里云百炼接口启用流式传输。
3. 为DeepSeek接口启用流式传输。
4. 将阿里云百炼的默认模型改为“qwen-plus”，因为默认的“qwen-turbo”不能满足文本润色等基础需求。如果想要获得和deepseek-v3相等的性能，应该在后续改用“qwen-max”。

![自定义模型流式传输](https://github.com/user-attachments/assets/7edd0944-aff6-40fc-9581-d31372ecf05e)
