### PR TITLE
refactor: 重写消息框样式

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,9 +72,7 @@
 
                 <!-- 输出框 -->
                 <div class="output-container">
-                    <div id="prompt-output" class="output-content" draggable="true">
-                        等待第一次提交……
-                    </div>
+                    <div id="prompt-output" class="output-content" draggable="true">等待第一次提交...</div>
                 </div>
             </div>
         </aside>

--- a/js/customDialogs.js
+++ b/js/customDialogs.js
@@ -1,0 +1,177 @@
+/**
+ * 创建基础对话框HTML结构
+ */
+function createDialogBase() {
+    if (!document.getElementById('dialog-styles')) {
+        const style = document.createElement('style');
+        style.id = 'dialog-styles';
+        style.textContent = `
+        /* 提示和确认对话框 */
+        .alert-dialog, .confirm-dialog {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background-color: rgba(0, 0, 0, 0.5);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          z-index: 20001;
+          user-select: none;
+        }
+        
+        .alert-content, .confirm-content {
+          background-color: var(--color-bg-primary);
+          padding: var(--spacing-xxl);
+          border-radius: var(--radius-xl);
+          width: 90%;
+          max-width: 400px;
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-lg);
+        }
+        
+        .alert-message, .confirm-message {
+          color: var(--color-text-primary);
+          font-size: 16px;
+          line-height: 1.5;
+          white-space: pre-wrap;
+        }
+        
+        .alert-buttons, .confirm-buttons {
+          display: flex;
+          justify-content: flex-end;
+          gap: var(--spacing-sm);
+        }
+        
+        .alert-buttons button, .confirm-buttons button {
+          padding: var(--spacing-sm) var(--spacing-lg);
+          border: none;
+          border-radius: var(--radius-md);
+          cursor: pointer;
+          font-size: 14px;
+          transition: all 0.2s;
+        }
+        
+        .alert-confirm, .confirm-ok {
+          background-color: var(--color-primary);
+          color: var(--color-bg-primary);
+        }
+        
+        .alert-confirm:hover, .confirm-ok:hover {
+          background-color: var(--color-primary-dark);
+        }
+        
+        .confirm-cancel {
+          background-color: var(--color-bg-secondary);
+          color: var(--color-text-primary);
+        }
+        
+        .confirm-cancel:hover {
+          background-color: var(--color-border);
+        }
+      `;
+        document.head.appendChild(style);
+    }
+}
+
+/**
+ * 显示提示框
+ * @param {string} message 提示消息
+ * @param {string} [title] 标题
+ * @returns {Promise<void>}
+ */
+function showAlert(message, title) {
+    return new Promise((resolve) => {
+        createDialogBase();
+
+        // 移除已存在的对话框
+        const existing = document.querySelector('.alert-dialog');
+        if (existing) existing.remove();
+
+        const dialog = document.createElement('div');
+        dialog.className = 'alert-dialog';
+
+        dialog.innerHTML = `
+        <div class="alert-content">
+          ${title ? `<h3>${title}</h3>` : ''}
+          <div class="alert-message">${message}</div>
+          <div class="alert-buttons">
+            <button class="alert-confirm">确定</button>
+          </div>
+        </div>
+      `;
+
+        document.body.appendChild(dialog);
+
+        dialog.querySelector('.alert-confirm').addEventListener('click', () => {
+            dialog.remove();
+            resolve();
+        });
+    });
+}
+/*
+使用示例：
+showAlert('操作成功!').then(() => {
+    console.log('用户关闭了提示框');
+});
+*/
+
+/**
+ * 显示确认框
+ * @param {string} message 确认消息
+ * @param {string} [title] 标题
+ * @returns {Promise<boolean>} 用户是否确认
+ */
+function showConfirm(message, title) {
+    return new Promise((resolve) => {
+        createDialogBase();
+
+        // 移除已存在的对话框
+        const existing = document.querySelector('.confirm-dialog');
+        if (existing) existing.remove();
+
+        const dialog = document.createElement('div');
+        dialog.className = 'confirm-dialog';
+
+        dialog.innerHTML = `
+        <div class="confirm-content">
+          ${title ? `<h3>${title}</h3>` : ''}
+          <div class="confirm-message">${message}</div>
+          <div class="confirm-buttons">
+            <button class="confirm-cancel">取消</button>
+            <button class="confirm-ok">确定</button>
+          </div>
+        </div>
+      `;
+
+        document.body.appendChild(dialog);
+
+        dialog.querySelector('.confirm-cancel').addEventListener('click', () => {
+            dialog.remove();
+            resolve(false);
+        });
+
+        dialog.querySelector('.confirm-ok').addEventListener('click', () => {
+            dialog.remove();
+            resolve(true);
+        });
+    });
+}
+/*
+使用示例：
+showConfirm('确定要删除此项吗?').then((confirmed) => {
+    if (confirmed) {
+        console.log('用户确认');
+    } else {
+        console.log('用户取消');
+    }
+});
+*/
+
+// 导出函数
+export {
+    showAlert,
+    showConfirm
+};

--- a/js/markdownHandler.js
+++ b/js/markdownHandler.js
@@ -1,3 +1,5 @@
+import { showAlert, showConfirm } from './customDialogs.js';
+
 export class MarkdownHandler {
     constructor(containerElement) {
         this.container = containerElement;
@@ -15,7 +17,7 @@ export class MarkdownHandler {
             this.createCards(paragraphs);
         } catch (error) {
             console.error('文件处理错误:', error);
-            alert('文件处理出错，请重试');
+            showAlert('文件处理出错，请重试');
         }
     }
 
@@ -94,33 +96,35 @@ export class MarkdownHandler {
         deleteBtn.innerHTML = '×';
         deleteBtn.onclick = (e) => {
             e.stopPropagation();
-            if (confirm('确定要删除这个卡片吗？')) {
-                // 删除指向该卡片的连接
-                const cardId = card.dataset.cardId;
-                if (window.connectionManager) {
-                    // 删除蓝色插座的连接（包括来自提示词卡片和其他文本卡片的连接）
-                    const textCardPort = card.querySelector('.text-card-port');
-                    if (textCardPort) {
-                        window.connectionManager.removePortConnection(textCardPort);
-                    }
-                    
-                    // 删除紫色插头的连接（该卡片发起的链式连接）
-                    const chainPort = card.querySelector('.text-card-chain-port');
-                    if (chainPort) {
-                        window.connectionManager.removePortConnection(chainPort);
-                    }
-                    
-                    // 删除指向该卡片的所有连接
-                    window.connectionManager.connections.forEach((connection, connectionId) => {
-                        if (connection.endPort.closest('.paragraph-card')?.dataset.cardId === cardId) {
-                            window.connectionManager.removePortConnection(connection.startPort);
+            showConfirm('确定要删除这个卡片吗？').then((confirmed) => {
+                if (confirmed) {
+                    // 删除指向该卡片的连接
+                    const cardId = card.dataset.cardId;
+                    if (window.connectionManager) {
+                        // 删除蓝色插座的连接（包括来自提示词卡片和其他文本卡片的连接）
+                        const textCardPort = card.querySelector('.text-card-port');
+                        if (textCardPort) {
+                            window.connectionManager.removePortConnection(textCardPort);
                         }
-                    });
+                        
+                        // 删除紫色插头的连接（该卡片发起的链式连接）
+                        const chainPort = card.querySelector('.text-card-chain-port');
+                        if (chainPort) {
+                            window.connectionManager.removePortConnection(chainPort);
+                        }
+                        
+                        // 删除指向该卡片的所有连接
+                        window.connectionManager.connections.forEach((connection, connectionId) => {
+                            if (connection.endPort.closest('.paragraph-card')?.dataset.cardId === cardId) {
+                                window.connectionManager.removePortConnection(connection.startPort);
+                            }
+                        });
+                    }
+                    
+                    card.remove();
+                    this.cards = this.cards.filter(c => c !== card);
                 }
-                
-                card.remove();
-                this.cards = this.cards.filter(c => c !== card);
-            }
+            });
         };
         actions.appendChild(deleteBtn);
         card.appendChild(actions);

--- a/js/promptCard.js
+++ b/js/promptCard.js
@@ -1,3 +1,5 @@
+
+import { showAlert, showConfirm } from './customDialogs.js';
 // 生成唯一ID的辅助函数
 function generateUniqueId(prefix = 'card') {
     return `${prefix}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
@@ -108,18 +110,20 @@ export class PromptCard {
         const deleteBtn = card.querySelector('.delete-btn');
         deleteBtn.onclick = (e) => {
             e.stopPropagation();
-            if (confirm('确定要删除这个提示词卡片吗？')) {
-                // 删除所有连接端口的连接
-                const ports = card.querySelectorAll('.connection-port');
-                if (window.connectionManager) {
-                    ports.forEach(port => {
-                        window.connectionManager.removePortConnection(port);
-                    });
+            showConfirm('确定要删除这个提示词卡片吗？').then((confirmed) => {
+                if (confirmed) {
+                    // 删除所有连接端口的连接
+                    const ports = card.querySelectorAll('.connection-port');
+                    if (window.connectionManager) {
+                        ports.forEach(port => {
+                            window.connectionManager.removePortConnection(port);
+                        });
+                    }
+                    
+                    // 从卡片管理器中移除
+                    window.cardManager.deleteCard(this.id);
                 }
-                
-                // 从卡片管理器中移除
-                window.cardManager.deleteCard(this.id);
-            }
+            });
         };
 
         return card;
@@ -273,9 +277,9 @@ export class PromptCardManager {
             // 处理删除按钮点击
             if (e.target.matches('.delete-btn')) {
                 e.stopPropagation();
-                if (confirm('确定要删除这个提示词卡片吗？')) {
-                    this.deleteCard(promptCard.id);
-                }
+                showConfirm('确定要删除这个提示词卡片吗？').then((confirmed) => {
+                    if (confirmed) this.deleteCard(promptCard.id);
+                });
                 return;
             }
 
@@ -394,7 +398,7 @@ export class PromptCardManager {
                 }
                 dialog.remove();
             } else {
-                alert('标题和提示词内容不能为空');
+                showAlert('标题和提示词内容不能为空');
             }
         });
 
@@ -459,9 +463,9 @@ export function importCards() {
 
             // 显示成功提示
             const count = cardsData.length;
-            alert(`成功导入 ${count} 个卡片`);
+            showAlert(`成功导入 ${count} 个卡片`);
         } catch (error) {
-            alert('导入失败：' + error.message);
+            showAlert('导入失败：' + error.message);
         }
     };
     
@@ -480,23 +484,25 @@ export function initializeCardManagement() {
     
     // 添加清空功能
     clearButton.addEventListener('click', () => {
-        if (confirm('确定要删除所有提示词卡片吗？此操作不可撤销。')) {
-            const cardsContainer = document.querySelector('.prompt-cards');
+        showConfirm('确定要删除所有提示词卡片吗？此操作不可撤销。').then((confirmed) => {
+            if (confirmed) {
+                const cardsContainer = document.querySelector('.prompt-cards');
             
-            // 先删除所有提示词卡片的连接
-            cardsContainer.querySelectorAll('.prompt-card').forEach(card => {
-                const ports = card.querySelectorAll('.connection-port');
-                if (window.connectionManager) {
-                    ports.forEach(port => {
-                        window.connectionManager.removePortConnection(port);
-                    });
-                }
-            });
-            
-            // 然后清空容器和卡片管理器
-            cardsContainer.innerHTML = '';
-            window.cardManager.cards.clear();
-        }
+                // 先删除所有提示词卡片的连接
+                cardsContainer.querySelectorAll('.prompt-card').forEach(card => {
+                    const ports = card.querySelectorAll('.connection-port');
+                    if (window.connectionManager) {
+                        ports.forEach(port => {
+                            window.connectionManager.removePortConnection(port);
+                        });
+                    }
+                });
+                
+                // 然后清空容器和卡片管理器
+                cardsContainer.innerHTML = '';
+                window.cardManager.cards.clear();
+            }
+        });
     });
 
     // 添加清除连线功能

--- a/script.js
+++ b/script.js
@@ -1,3 +1,4 @@
+import { showAlert, showConfirm } from './js/customDialogs.js';
 import { PromptCardManager } from './js/promptCard.js';
 import { MarkdownHandler } from './js/markdownHandler.js';
 import { ConnectionManager } from './js/connectionManager.js';
@@ -263,18 +264,20 @@ document.getElementById('export-button').addEventListener('click', () => {
 
 // 添加删除所有段落的功能
 document.getElementById('clear-paragraphs').addEventListener('click', () => {
-    if (confirm('确定要删除所有段落卡片吗？此操作不可撤销。')) {
-        // 清空所有段落卡片
-        paragraphContainer.innerHTML = '';
-        
-        // 清除所有连接
-        if (window.connectionManager) {
-            window.connectionManager.clearAllConnections();
-        }
+    showConfirm('确定要删除所有段落卡片吗？此操作不可撤销。').then((confirmed) => {
+        if (confirmed) {
+            // 清空所有段落卡片
+            paragraphContainer.innerHTML = '';
+            
+            // 清除所有连接
+            if (window.connectionManager) {
+                window.connectionManager.clearAllConnections();
+            }
 
-        // 重置导入计数器
-        markdownHandler.importCount = 0;
-    }
+            // 重置导入计数器
+            markdownHandler.importCount = 0;
+        }
+    });
 });
 
 // 模拟API调用
@@ -319,10 +322,7 @@ function showCustomModelDialog() {
         const apiKey = dialog.querySelector('#api-key').value.trim();
         const model = dialog.querySelector('#model-name').value.trim();
 
-        if (!baseUrl || !apiKey || !model) {
-            alert('请填写所有必要信息');
-            return;
-        }
+        if (!baseUrl || !apiKey || !model) return showAlert('请填写所有必要信息');
 
         // 更新配置
         API_CONFIG.CUSTOM_MODEL = {
@@ -343,9 +343,9 @@ CUSTOM_MODEL: {
         
         console.log('新的自定义模型配置：');
         console.log(configText);
-        alert('配置已更新！请记得将新的配置保存到 config.js 文件中。\n\n配置信息已输出到控制台，你可以直接复制使用。');
-
-        dialog.remove();
+        showAlert('配置已更新！请记得将新的配置保存到 config.js 文件中。\n配置信息已输出到控制台，你可以直接复制使用。').then(() => {
+            dialog.remove();
+        });
     });
 
     // 取消按钮事件
@@ -461,10 +461,7 @@ async function showOllamaDialog() {
 
     // 确定按钮事件
     dialog.querySelector('.confirm-btn').addEventListener('click', () => {
-        if (!window.ollamaModel) {
-            alert('请选择一个模型');
-            return;
-        }
+        if (!window.ollamaModel) return showAlert('请选择一个模型');
         dialog.remove();
     });
 }

--- a/script.js
+++ b/script.js
@@ -56,7 +56,7 @@ window.addEventListener('scroll', () => connectionManager.updateConnections());
 // 拖拽开始时记录内容
 promptOutput.addEventListener('dragstart', (e) => {
     const content = promptOutput.textContent.trim();
-    if (content && content !== '等待提交提示词...' && content !== 'AI思考中...') {
+    if (content && content !== '等待第一次提交...' && content !== 'AI思考中...') {
         e.dataTransfer.setData('text/plain', content);
         // 添加拖拽效果
         promptOutput.style.opacity = '0.5';

--- a/styles/components/dialogs.css
+++ b/styles/components/dialogs.css
@@ -9,7 +9,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 20000;
+    user-select: none;
 }
 
 .dialog-content {
@@ -90,7 +91,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 20000;
+    user-select: none;
 }
 
 .custom-model-content {

--- a/styles/components/dialogs.css
+++ b/styles/components/dialogs.css
@@ -188,7 +188,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: 20000;
+    user-select: none;
 }
 
 .ollama-content {

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -3,6 +3,7 @@
     display: flex;
     min-height: 100vh;
     overflow: hidden;
+    user-select: none;
 }
 
 /* 侧边栏 */


### PR DESCRIPTION
## 重写
本次提交使用自定义的消息框样式替换了原生的`alert`和`confirm`，使整体视觉风格更加统一。  
自定义的消息框样式及函数由`customDialogs.js`统一管理。  
![屏幕截图 2025-04-17 140103](https://github.com/user-attachments/assets/ae835433-d290-4fec-8dd7-69a2b7be4e7d)  
![屏幕截图 2025-04-17 140125](https://github.com/user-attachments/assets/c1aa144c-82ed-442a-9a98-b787a3a8bd49)

## 修复
1. 让不应该被选中的元素无法被选中。
2. 修复了连接线图层会错误出现在一些元素之上的问题。
3. 修复了由于if条件与输出框内容不匹配导致的拖拽判定错误。